### PR TITLE
Add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+Copyright (c) 2018 Forge Development LLC
+
+This software is provided 'as-is', without any express or implied warranty. In no event will the authors be held liable for any damages arising from the use of this software or data.
+
+Permission is granted to anyone to use this software and data for any purpose, including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software and data must not be misrepresented; you must not claim that you wrote the original software or data. If you use this software or data in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+
+2. Altered versions must be plainly marked as such, and must not be misrepresented as being the original.
+
+3. This notice may not be removed or altered from any distribution.


### PR DESCRIPTION
Currently the license of the data in this repo is easy to miss, since it's only publicly stated in [a commit message](https://github.com/MinecraftForge/MCPConfig/commit/e829c044aec47989a5bbef2def1de40bd89d60ae) in the MCPConfig repo, in a way that makes it non-obvious what exactly it applies to.

In the NeoForge Discord it [has been clarified](https://github.com/LegacyModdingMC/MCPMappingsArchive/wiki/MCP-License-Discussion) that the same license does in fact apply to the MCPBot exports. To make this more clear to everyone, this PR adds the license text to this repo.
